### PR TITLE
Work on alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,4 @@ RUN apk add --no-cache --virtual isatools-build-deps \
             python3-dev  \
     && pip3 install isatools==0.9.4 \
     && apk del isatools-build-deps \
-    && rm -rf /var/cache/apk/* \
-    && rm -rf /tmp/* /var/tmp/*
+    && rm -rf /root/.cache # pip's cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,18 @@ LABEL software.version="0.9.4"
 LABEL version="1.1"
 LABEL software="ISA API"
 
-RUN echo "Installing software" >&2 \
-    && apk add --no-cache python3 bash \
-    && apk add --no-cache --virtual isatools-build-deps ca-certificates g++ python3-dev libxml2-dev libxslt-dev \
+RUN echo "Installing software" >&2
+RUN apk add --no-cache \
+                bash \
+                libxslt \
+                python3
+
+RUN apk add --no-cache --virtual isatools-build-deps \
+            ca-certificates \
+            g++ \
+            libxml2-dev \
+            libxslt-dev \
+            python3-dev  \
     && pip3 install isatools==0.9.4 \
     && apk del isatools-build-deps \
     && rm -rf /var/cache/apk/* \


### PR DESCRIPTION
This PR adds `libxslt` to the image.  This is sufficient to get the current set of tests on [container-mtblisa](https://github.com/phnmnl/container-mtblisa) to run correctly (I presume this run time dependency has become mandatory because of the update to isatools 0.9.4).

Also, this PR shaves another 40 MBs from the size of the image by cleaning `pip`'s cache under `/root/.cache`.